### PR TITLE
Add workflows to test triage automation

### DIFF
--- a/.github/workflows/_create-meeting-notes.yml
+++ b/.github/workflows/_create-meeting-notes.yml
@@ -1,0 +1,223 @@
+# Reusable workflow based on:
+# Adapted from:
+#   https://github.com/mfisher87/hackmd-meeting-notes-action
+#   https://github.com/conda/governance/blob/main/.github/workflows/_create-meeting-notes-pr.yml
+# Vendored from https://github.com/Quansight-Labs/hackmd-meeting-notes-action
+
+name: Create HackMD Meeting Notes
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_call:
+    inputs:
+      template_path:
+        description: >-
+          Path (relative to the repository root) to the HackMD template. Supports Jinja.
+          Environment variables available in the `env` dict.
+          Date available in the `date` datetime object.
+          It MUST contain a one-line `# H1 header`.
+        required: true
+        type: string
+      output_path:
+        description: Output path for the rendered template. Accepts `date` command syntax.
+        required: true
+        type: string
+      branch_name:
+        description: >-
+          Name for the branch that will be created with the new document.
+          Also used for the HackMD permalink.
+          Accepts `date` command syntax.
+        required: false
+        default: '%Y-%m-%d-meeting-notes'
+        type: string
+      hackmd_team:
+        description: HackMD team identifier
+        required: true
+        type: string
+      pr_title:
+        description: Title to be used in the submitted PR. Accepts `date` command syntax.
+        required: false
+        default: Add meeting notes %Y-%m-%d
+        type: string
+      pr_body:
+        description: >-
+          Body to be used in the submitted PR.
+          Environment variables available in `${env.XXXX}`.
+          Other options for interpolated strings `${...}` at https://github.com/actions/github-script
+        required: false
+        type: string
+        default: |
+          New meeting notes available at ${env.hackmd_doc_url}
+
+          Once done with the meeting, sync the note back to the repository using the `sync-meeting-notes-pr` workflow.
+          We recommend adding a job that is triggered by adding a label or posting a comment.
+          Labels are usually better because the permissions are usually restricted to maintainers.
+      date:
+        description: >-
+          Date to use for `date` syntax interpolation in strings. Defaults to date when running.
+          MUST be understood by `date --date`, but probably better to stick a known standard
+          (e.g. use ISO8601 format in UTC `2023-01-11T09:00:00Z`).
+        required: false
+        type: string
+        default: now
+      force_push:
+        description: Whether to `git push -f` if the target branch already exists
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: If true, do not actually push
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      GITHUB_USER_TOKEN:
+        description: A token with sufficient permissions to commit and push to the target repository
+        required: false
+      HACKMD_TOKEN:
+        description: API token for HackMD.io
+        required: true
+
+jobs:
+  main:
+    name: Create meeting notes PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - name: Set up dependencies
+        run: |
+          python3 -V
+          python3 -m pip install jinja2 requests httpx
+      - name: Prepare date
+        run: |
+          chosen_date="$(date -I -u --date "${{ inputs.date || 'now' }}")"
+          echo "chosen_date=${chosen_date}" >> $GITHUB_ENV
+      - name: Prepare branch
+        run: |
+          # Create new branch
+          branch_name=$(date --date "$chosen_date" "+${{ inputs.branch_name || '%Y-%m-%d-meeting-notes' }}")
+          if [[ "${{ inputs.force_push }}" == "true" ]]; then
+            git checkout -b "${branch_name}" || git checkout "${branch_name}"
+          else
+            git checkout -b "${branch_name}"
+          fi
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
+      - name: Render template
+        run: |
+          # Render template
+          output_path=$(date --date "$chosen_date" "+${{ inputs.output_path ||  'meeting-notes/archive/%Y-%m-%d-triage_agenda_and_minutes.md' }}")
+          export output_path
+          mkdir -p "$(dirname "$output_path")"
+          python3 > "$output_path" <<EOF
+          from jinja2 import Template, DebugUndefined
+          import sys
+          import subprocess
+          import os
+          from datetime import datetime
+          from pathlib import Path
+          triage_items_text=subprocess.run([sys.executable, "scripts/gen_triage_issues.py"], capture_output=True, text=True, check=True).stdout
+          template = Template(Path("${{ inputs.template_path || 'meeting-notes/triage_TEMPLATE.md' }}").read_text(), undefined=DebugUndefined)
+          print(
+            template.render(
+              env=os.environ,
+              date=datetime.fromisoformat(os.environ["chosen_date"]),
+              triage_issues=triage_items_text,
+            )
+          )
+          EOF          
+          echo "output_path=$output_path" >> $GITHUB_ENV
+          note_title="$(awk '/^# .*/{print substr($0,3); exit}' "$output_path")"
+          echo "note_title=$note_title" >> $GITHUB_ENV
+      - name: Commit changes
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git add "$output_path"
+          git commit -m "Add $output_path"
+      - name: Sync with HackMD
+        if: ${{ !inputs.dry_run }}
+        env:
+          HACKMD_TOKEN: ${{ secrets.HACKMD_TOKEN }}
+        shell: python
+        run: |
+          import os
+          from pathlib import Path
+          import requests
+          url = "https://api.hackmd.io/v1/teams/${{ inputs.hackmd_team }}/notes"
+          headers = {"Authorization": f"Bearer {os.environ['HACKMD_TOKEN']}"}
+          data = {
+            "title": os.environ["note_title"],
+            "content": Path(os.environ["output_path"]).read_text(errors="replace"),
+            "readPermission": "guest",
+            "writePermission": "signed_in",
+          }
+          r = requests.post(url, json=data, headers=headers)
+          if not r.ok:
+            print(r.content)
+            r.raise_for_status()
+          data = r.json()
+          print(data)
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+            print(f"hackmd_doc_id={data['id']}", file=f)
+            print(f"hackmd_doc_url={data['publishLink']}", file=f)
+      - name: (Force) Push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config push.default upstream
+          if [[ "${{ inputs.force_push }}" == "true" ]]; then
+            git push -f origin "${branch_name}"
+          else
+            git push origin "${branch_name}"
+          fi
+      - name: Prepare PR contents
+        run: |
+          echo "pr_title=$(date --date "$chosen_date" "+${{ inputs.pr_title || 'Meeting notes for %Y-%m-%d' }}")" >> $GITHUB_ENV
+          # We need to escape the backticks in markdown so JS interpolation does not choke
+          cat <<'EOF' > "$RUNNER_TEMP/pr-body"
+          ${{ inputs.pr_body || 'PR BODY TEXT EXAMPLE' }}
+          EOF
+          EOV=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "pr_body<<$EOV" >> $GITHUB_ENV
+          sed 's/`/\\`/g' "$RUNNER_TEMP/pr-body" >> $GITHUB_ENV
+          echo "$EOV" >> $GITHUB_ENV
+      - name: Create PR
+        if: ${{ !inputs.dry_run }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            let env = process.env
+            const resp = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: env.branch_name,
+              base: "main",
+              title: env.pr_title,
+            });
+            let pr_body =
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: resp.data.number,
+              body: `
+            <!--
+            DO NOT EDIT THIS BLOCK
+            HACKMDURL=${env.hackmd_doc_url}
+            HACKMDID=${env.hackmd_doc_id}
+            DOCPATH=${env.output_path}
+            -->
+            ${{ env.pr_body }}
+            `
+            })
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          template_path: ${{ inputs.template_path }}
+          hackmd_team: ${{ inputs.hackmd_team }}

--- a/.github/workflows/_create-meeting-notes.yml
+++ b/.github/workflows/_create-meeting-notes.yml
@@ -73,6 +73,10 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+        pr_number:
+            description: "PR number of the created PR"
+            value: ${{ jobs.main.outputs.pr_number }}
     secrets:
       GITHUB_USER_TOKEN:
         description: A token with sufficient permissions to commit and push to the target repository
@@ -188,6 +192,7 @@ jobs:
           sed 's/`/\\`/g' "$RUNNER_TEMP/pr-body" >> $GITHUB_ENV
           echo "$EOV" >> $GITHUB_ENV
       - name: Create PR
+        id: create_pr
         if: ${{ !inputs.dry_run }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -200,6 +205,8 @@ jobs:
               base: "main",
               title: env.pr_title,
             });
+            core.setOutput('pr_number', resp.data.number.toString())
+
             let pr_body =
 
             await github.rest.pulls.update({
@@ -221,3 +228,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           template_path: ${{ inputs.template_path }}
           hackmd_team: ${{ inputs.hackmd_team }}
+    outputs:
+        pr_number: ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/_create-meeting-notes.yml
+++ b/.github/workflows/_create-meeting-notes.yml
@@ -126,7 +126,7 @@ jobs:
           from datetime import datetime
           from pathlib import Path
           triage_items_text=subprocess.run([sys.executable, "scripts/gen_triage_issues.py"], capture_output=True, text=True, check=True).stdout
-          template = Template(Path("${{ inputs.template_path || 'meeting-notes/triage_TEMPLATE.md' }}").read_text(), undefined=DebugUndefined)
+          template = Template(Path("${{ inputs.template_path || 'meetings/triage_TEMPLATE.md' }}").read_text(), undefined=DebugUndefined)
           print(
             template.render(
               env=os.environ,

--- a/.github/workflows/_sync-meeting-notes.yml
+++ b/.github/workflows/_sync-meeting-notes.yml
@@ -1,0 +1,120 @@
+# Reusable workflow based on:
+# Adapted from:
+#   https://github.com/mfisher87/hackmd-meeting-notes-action
+#   https://github.com/conda/governance/blob/main/.github/workflows/_sync-meeting-notes-pr.yml
+# Vendored from https://github.com/Quansight-Labs/hackmd-meeting-notes-action
+
+name: Sync HackMD Meeting Notes
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: PR number being synced
+        required: true
+        type: string
+      hackmd_team:
+        description: HackMD team identifier
+        required: true
+        type: string
+      dry_run:
+        description: If enabled, do not commit changes
+        required: false
+        type: boolean
+    secrets:
+      GITHUB_USER_TOKEN:
+        description: A token with sufficient permissions to commit and push to the target repository
+        required: false
+      HACKMD_TOKEN:
+        description: API token for HackMD.io
+        required: true
+
+jobs:
+  main:
+    name: Sync notes from HackMD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Checkout the PR branch"
+        run: gh pr checkout ${{ inputs.pr_number }}
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - name: Set up dependencies
+        run: |
+          python3 -V
+          python3 -m pip install requests
+      - name: Get PR description
+        id: pr-description
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          result-encoding: string
+          script: |
+            let env = process.env
+            const resp = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            return resp.data.body
+      - name: Parse PR description
+        shell: python
+        env:
+          PR_DESCRIPTION: ${{ steps.pr-description.outputs.result }}
+        run: |
+          import os, sys
+          from pathlib import Path
+          result = os.environ["PR_DESCRIPTION"].strip()
+          found = 0
+          for line in result.splitlines():
+            line = line.strip()
+            if line.startswith(("HACKMDID=", "DOCPATH=")):
+              key, value = line.split("=", 1)
+              with open(os.environ["GITHUB_ENV"], "a") as f:
+                f.write(f"{key}={value}\n")
+              found += 1
+              print("Found key", key)
+          if found != 2:
+            print("PR description parsing error! Must contain HACKMDID=value and DOCPATH=value!")
+            sys.exit(1)
+      - name: Sync from HackMD
+        if: ${{ !inputs.dry_run }}
+        shell: python
+        env:
+          HACKMD_TOKEN: ${{ secrets.HACKMD_TOKEN }}
+          HACKMD_TEAM: ${{ inputs.hackmd_team }}
+        run: |
+          import os, sys
+          from pathlib import Path
+          import requests
+          url = f"https://api.hackmd.io/v1/teams/{os.environ['HACKMD_TEAM']}/notes/{os.environ['HACKMDID']}"
+          headers = {"Authorization": f"Bearer {os.environ['HACKMD_TOKEN']}"}
+          r = requests.get(url, headers=headers)
+          if not r.ok:
+            print(r.content)
+            r.raise_for_status()
+          data = r.json()
+          print(data)
+          Path(os.environ['DOCPATH']).write_text(data['content'])
+          sys.exit(0)
+      - name: Commit changes (if any)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -x
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git status
+          if ! git diff --exit-code "$DOCPATH"; then
+            git add "$DOCPATH"
+            git commit -m "Update $DOCPATH"
+            git push origin $(git rev-parse --abbrev-ref HEAD)
+          else
+            echo "No changes detected."
+          fi

--- a/.github/workflows/_sync-meeting-notes.yml
+++ b/.github/workflows/_sync-meeting-notes.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Checkout the PR branch"
         run: gh pr checkout ${{ inputs.pr_number }}
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_USER_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token  }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'

--- a/.github/workflows/triage-assist.md
+++ b/.github/workflows/triage-assist.md
@@ -1,0 +1,56 @@
+---
+on:
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: "PR number for the meeting notes"
+                required: true
+                type: string
+
+permissions:
+    contents: read
+    actions: read
+
+safe-outputs:
+    add-comment:
+        max: 1
+        target: "*"
+        hide-older-comments: true
+---
+
+# Triage Analysis for Jupyter Triage Meeting
+
+Read the content of PR #${{ github.event.inputs.pr_number }} in this repository.
+Extract the GitHub issue URLs from the meeting notes, typically under the `## Meeting Notes` section. These are the issues the triage team will be discussing.
+
+You are a triage assistant helping to analyze these issues which fall across a few repositories of the Project Jupyter ecosystem. These recent issues pending triage and are identified with the `status:Needs triage` label.
+
+For each issue, provide the following analysis:
+
+## 1. Summary
+Write 1-2 sentences describing what the issue is about and whether it is a bug report,feature request, documentation issue or question.
+
+## 2. Additional Information
+If there are any suggestions for additional information that would be help the triage team better understand or reproduce the issue, please make note of those. If the current title is vague or does not reflect the issue content, suggest a clearer title or otherwise note that the title is adequate. Fetch the label list of the issues' parent repository and recommend any existing labels that should be applied while explaining the reasoning. Consider the component area and type of issue as well as whether it could be considered a good first issue.
+
+## 3. Related Issues
+Search the same repository for up to 2 related open or recently closed issues. Provide the URL and a one-sentence explanation for each. Flag any that appear to be duplicates.
+
+## Output
+Provide your analysis in a comment on the PR documenting this week's notes, ${{ github.event.inputs.pr_number }}. Group results by repository and use the following structure:
+
+Repository
+* Issue link
+    * Issue Title
+    * Summary
+    * Additional Information
+        * Suggested Title / Title is Adequate
+        * Recommended labels
+            * label - reason
+            * label - reason
+    * Related Issues
+        * related issue link - reason
+        * related issue link - reason
+    * Possible duplicate?: No / Yes - explanation
+
+Repeat the same structure per each issue in the repo

--- a/.github/workflows/triage-assist.md
+++ b/.github/workflows/triage-assist.md
@@ -23,7 +23,7 @@ safe-outputs:
 Read the content of PR #${{ github.event.inputs.pr_number }} in this repository.
 Extract the GitHub issue URLs from the meeting notes, typically under the `## Meeting Notes` section. These are the issues the triage team will be discussing.
 
-You are a triage assistant helping to analyze these issues which fall across a few repositories of the Project Jupyter ecosystem. These recent issues pending triage and are identified with the `status:Needs triage` label.
+You are a triage assistant helping to analyze these issues which fall across a few repositories of the Project Jupyter ecosystem. These recent issues pending triage and are identified with the `status:Needs Triage` label.
 
 For each issue, provide the following analysis:
 

--- a/.github/workflows/triage-notes.yml
+++ b/.github/workflows/triage-notes.yml
@@ -1,0 +1,77 @@
+# Workflow based on https://github.com/jupyter/community-committee/blob/main/.github/workflows/meeting-notes.yml
+# Referenced from: https://github.com/mfisher87/hackmd-meeting-notes-action/
+# Vendored from: https://github.com/Quansight-Labs/hackmd-meeting-notes-action
+
+name: "Setup / sync meeting notes"
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: |
+          Date of the meeting in `date --date` format, e.g.:
+          "today", "tomorrow", "next wednesday", "2025-02-05", etc.
+          See <https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html>
+        required: false
+        default: "today"
+        type: "string"
+
+  issue_comment:
+    types:
+      - "created"
+      - "edited"
+
+
+# IMPORTANT: Enable 'Allow GitHub Actions to create and approve pull requests'
+# in repo and organization Actions Settings.
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+
+jobs:
+  create:
+    name: "Create PR for meeting notes"
+    if: "github.event_name == 'workflow_dispatch'"
+    uses: ./.github/workflows/_create-meeting-notes.yml
+    with:
+      date: "${{ inputs.date }}"
+      template_path: "meetings/triage_TEMPLATE.md"
+      # Repository path
+      output_path: "meetings/archive/%Y%m%d-triage_agenda_and_minutes.md"
+      hackmd_team: "jupyter-community"
+      branch_name: "%Y-%m-%d-meeting-notes"
+      force_push: true
+      pr_title: "Add Triage meeting notes %Y-%m-%d"
+      pr_body: |
+        Meeting notes initialized at ${env.hackmd_doc_url}.
+
+        After the meeting, sync the notes from HackMD to this PR by commenting:
+
+        ```
+        /bot please sync notes
+        ```
+    secrets:
+      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
+
+  sync-comment-trigger:
+    name: "React to the triggering comment"
+    if: "${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot please sync notes') }}"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "React to the triggering comment"
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  sync:
+    name: "Sync notes from HackMD to PR"
+    needs:
+     - "sync-comment-trigger"
+    uses: ./.github/workflows/_sync-meeting-notes.yml
+    with:
+      pr_number: "${{ github.event.issue.number }}"
+      hackmd_team: "jupyter-triage-team"
+    secrets:
+      HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"

--- a/.github/workflows/triage-notes.yml
+++ b/.github/workflows/triage-notes.yml
@@ -39,7 +39,7 @@ jobs:
       template_path: "meetings/triage_TEMPLATE.md"
       # Repository path
       output_path: "meetings/archive/%Y%m%d-triage_agenda_and_minutes.md"
-      hackmd_team: "jupyter-community"
+      hackmd_team: "automation-testing"
       branch_name: "%Y-%m-%d-meeting-notes"
       force_push: true
       pr_title: "Add Triage meeting notes %Y-%m-%d"
@@ -85,6 +85,6 @@ jobs:
     uses: ./.github/workflows/_sync-meeting-notes.yml
     with:
       pr_number: "${{ github.event.issue.number }}"
-      hackmd_team: "jupyter-triage-team"
+      hackmd_team: "automation-testing"
     secrets:
       HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"

--- a/.github/workflows/triage-notes.yml
+++ b/.github/workflows/triage-notes.yml
@@ -54,6 +54,19 @@ jobs:
     secrets:
       HACKMD_TOKEN: "${{ secrets.HACKMD_TOKEN }}"
 
+  triage-analysis:
+    name: "Triage Analysis by Agent"
+    needs: create
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Dispatch triage assistant workflow
+        run: |
+          gh aw run triage-assist \
+            -f pr_number="${{ needs.create.outputs.pr_number }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
   sync-comment-trigger:
     name: "React to the triggering comment"
     if: "${{ github.event.issue.pull_request && contains(github.event.comment.body, '/bot please sync notes') }}"

--- a/.github/workflows/triage-notes.yml
+++ b/.github/workflows/triage-notes.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: "write"
   pull-requests: "write"
+  issues: "write"
 
 
 jobs:

--- a/meetings/triage_TEMPLATE.md
+++ b/meetings/triage_TEMPLATE.md
@@ -69,9 +69,9 @@ The issue should represent real, relevant, feasible work. In short, if a knowled
     b. bug
     c. feature parity
     d. Tag milestones
-5. Identify duplicates
-6. Respond to issues
-7. Assign another person
+3. Identify duplicates
+4. Respond to issues
+5. Assign another person
 
 Add milestone if you can achieve the goal.
 

--- a/meetings/triage_TEMPLATE.md
+++ b/meetings/triage_TEMPLATE.md
@@ -1,0 +1,93 @@
+---
+title: "Jupyter Issue Triage Meeting"
+description: |
+  A weekly gathering of the Jupyter Issue Triage Group.
+date: "{{ date.strftime('%Y-%m-%d') }}"
+author:
+  - name: "The Jupyter Issue Triage Group"
+categories:
+  - "Meeting notes"
+tags: [meeting-notes]
+---
+
+# Jupyter Issue Triage Meeting ({{ date.strftime("%Y-%m-%d") }})
+
+Triage issues in JupyterLab and corresponding projects.
+
+Meeting is typically held at 09:00 US Pacific time on Tuesdays.
+
+Meeting info: https://zoom.us/j/95228013874?pwd=Ep7HIk8t9JP6VToxt1Wj4P7K5PshC0.1
+
+Notes on GitHub: https://github.com/jupyterlab/frontends-team-compass/issues/268
+
+Previous notes:
+* https://github.com/jupyterlab/frontends-team-compass/issues/268 (Jan–Dec 2025)
+* https://github.com/jupyterlab/frontends-team-compass/issues/250#issuecomment-2441830653 (Jul–Dec 2024)
+* https://github.com/jupyterlab/frontends-team-compass/issues/228 (2024-01 through 2024-06)
+* https://github.com/jupyterlab/frontends-team-compass/issues/203 (2023-07 through 2023-12)
+* https://github.com/jupyterlab/frontends-team-compass/issues/169 (2023-01 through 2023-06)
+* https://github.com/jupyterlab/frontends-team-compass/issues/151 (2022-07 through 2022-12)
+* https://github.com/jupyterlab/frontends-team-compass/issues/137 (2022-01 through 2022-06)
+
+
+## Goals
+
+Act on long-running, highly demanded, or highly discussed issues to get them ready for development work.
+
+### Resources
+
+* https://jupyterlab.readthedocs.io/en/latest/developer/contributing.html#submitting-a-pull-request-contribution
+
+* There is a script to pull all current issues here: https://github.com/danyeaw/jupyter-triage-tool
+
+### Triage Process
+
+All requested information, where applicable, is provided. From the templates in JupyterLab’s issues:
+
+For a bug:
+
+* Description, preferably including screen shots
+* Steps to reproduce
+* Expected behavior
+* Context, such as OS, browser, JupyterLab version, and output or log excerpts
+
+For a feature request:
+* Description of the problem
+* Description of the proposed solution
+* Additional context
+
+The issue should represent real, relevant, feasible work. In short, if a knowledgeable person were to be assigned this issue, they would be able to complete it with a reasonable amount of effort and assistance, and it furthers the goals of the Jupyter project.
+
+* Issues should be unique; triage is the best time to identify duplicates.
+* Bugs represent valid expectations for use of Jupyter products and services.
+* Expectations for security, performance, accessibility, and localization match generally-accepted norms in the community that uses Jupyter products.
+* The issue represents work that one developer can commit to owning, even if they collaborate with other developers for feedback. Excessively large issues should be split into multiple issues, each triaged individually, or into team-compass issues to discuss more substantive changes.
+
+1. Read issues
+2. Tag issues; remove `status:Needs Triage` from issues we accept. Other useful tags include:
+    a. good first issue
+    b. bug
+    c. feature parity
+    d. Tag milestones
+5. Identify duplicates
+6. Respond to issues
+7. Assign another person
+
+Add milestone if you can achieve the goal.
+
+### Primary focus
+
+* [JupyterLab untriaged issues](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3ANeeds+Triage%22%20sort%3Acreated-asc)
+* [Notebook untriaged issues](https://github.com/jupyter/notebook/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3ANeeds+Triage%22%20sort%3Acreated-asc)
+* [JupyterLab Desktop untriaged issues](https://github.com/jupyterlab/jupyterlab-desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3ANeeds+Triage%22%20sort%3Acreated-asc)
+* [nbclassic untriaged issues](https://github.com/jupyter/nbclassic/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22status%3ANeeds%20Triage%22%20sort%3Acreated-asc)
+
+
+## Attendees
+| Name | Organization | Username |
+|------|--------------|----------|
+||||
+
+## Meeting Notes
+
+{{ triage_issues }}

--- a/scripts/gen_triage_issues.py
+++ b/scripts/gen_triage_issues.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "httpx",
+# ]
+# ///
+"""
+GitHub Issues Triage Scraper - UV Script
+Fetches untriaged issues from Jupyter repositories and generates markdown meeting notes.
+
+Usage: uv run triage.py
+
+Based on: https://github.com/danyeaw/jupyter-triage-tool (triage.py)
+Original author: Dan Yeaw
+See original repository for license terms.
+"""
+
+import httpx
+import argparse
+import asyncio
+from typing import Dict, List
+
+class GitHubTriageScraper:
+    def __init__(self):
+        self.headers = {
+            'Accept': 'application/vnd.github.v3+json',
+            'User-Agent': 'Jupyter-Triage-Scraper/1.0'
+        }
+        
+        # Repository configurations
+        self.repositories = {
+            'JupyterLab': 'jupyterlab/jupyterlab',
+            'Notebook': 'jupyter/notebook', 
+            'JupyterLab-Desktop': 'jupyterlab/jupyterlab-desktop',
+            'NBClassic': 'jupyter/nbclassic'
+        }
+
+    async def get_issues_for_repo(self, client: httpx.AsyncClient, repo_full_name: str) -> List[Dict]:
+        """Get issues with 'status:Needs Triage' label for a repository."""
+        url = f"https://api.github.com/repos/{repo_full_name}/issues"
+        
+        params = {
+            'state': 'open',
+            'labels': 'status:Needs Triage',
+            'sort': 'created',
+            'direction': 'asc',
+            'per_page': 100
+        }
+        
+        all_issues = []
+        page = 1
+        
+        while True:
+            params['page'] = page
+            
+            try:
+                response = await client.get(url, params=params)
+                response.raise_for_status()
+                
+                issues = response.json()
+                
+                if not issues:
+                    break
+                
+                # Filter out pull requests
+                issues = [issue for issue in issues if 'pull_request' not in issue]
+                
+                for issue in issues:
+                    all_issues.append({
+                        'number': issue['number'],
+                        'title': issue['title'],
+                        'url': issue['html_url'],
+                        'created_at': issue['created_at']
+                    })
+                
+                if len(issues) < params['per_page']:
+                    break
+                
+                page += 1
+                
+            except Exception as e:
+                print(f"Error fetching issues for {repo_full_name}: {e}")
+                break
+        
+        return sorted(all_issues, key=lambda x: x['number'])
+
+    async def get_all_issues(self, verbose: bool = False) -> Dict[str, List[Dict]]:
+        """Get issues from all repositories asynchronously."""
+        async with httpx.AsyncClient(headers=self.headers, timeout=30.0) as client:
+            tasks = []
+            
+            for repo_name, repo_full_name in self.repositories.items():
+                if verbose:
+                    print(f"Fetching issues for {repo_name} ({repo_full_name})...")
+                task = self.get_issues_for_repo(client, repo_full_name)
+                tasks.append((repo_name, task))
+            
+            results = {}
+            for repo_name, task in tasks:
+                issues = await task
+                results[repo_name] = issues
+                if verbose:
+                    print(f"Found {len(issues)} issues in {repo_name}")
+        
+        return results
+
+    def generate_meeting_template(self, issues_data: Dict[str, List[Dict]]) -> str:
+        """Generate meeting template only."""
+        lines = []
+        
+        for repo_name, issues in issues_data.items():
+            issue_count = len(issues)
+            
+            if issue_count == 0:
+                lines.append(f"Before the meeting, 0 issues in {repo_name} needed triage. After the meeting, none remain.")
+            else:
+                lines.append(f"Before the meeting, {issue_count} issues in {repo_name} needed triage. After the meeting, [UPDATE] remain.")
+                
+                for issue in issues:
+                    lines.append(f"* {issue['url']} ()")
+            
+            # Add newline between repository sections
+            lines.append("")
+        
+        return "\n".join(lines).rstrip()  # Remove trailing newline
+
+async def main():
+    """Main function."""
+    parser = argparse.ArgumentParser(description="A script that generates list of triage issues for markdown notes.")
+    parser.add_argument('--verbose', action='store_true', help="Verbose text output.")
+    args = parser.parse_args()
+
+    scraper = GitHubTriageScraper()
+
+    if args.verbose:
+        print("Fetching issues from all repositories...")
+
+    issues_data = await scraper.get_all_issues(args.verbose)
+
+    # Generate meeting template
+    meeting_template = scraper.generate_meeting_template(issues_data)
+    print(meeting_template)
+    print()
+
+    # Summary
+    if args.verbose:
+        total = sum(len(issues) for issues in issues_data.values())
+        print(f"Total: {total} issues")
+        for repo_name, issues in issues_data.items():
+            print(f"  {repo_name}: {len(issues)}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/gen_triage_issues.py
+++ b/scripts/gen_triage_issues.py
@@ -9,7 +9,7 @@
 GitHub Issues Triage Scraper - UV Script
 Fetches untriaged issues from Jupyter repositories and generates markdown meeting notes.
 
-Usage: uv run triage.py
+Usage: uv run gen_triage_issues.py
 
 Based on: https://github.com/danyeaw/jupyter-triage-tool (triage.py)
 Original author: Dan Yeaw


### PR DESCRIPTION
Automation workflow for managing meeting notes using GitHub Actions and HackMD integration. 
Reusable workflows for creating, syncing, and analyzing meeting notes, and a meeting notes template. 

**Automated Meeting Notes Management**

* Added a reusable workflow (`_create-meeting-notes.yml`) to automate the creation of meeting notes from a Jinja template, push them to a new branch, create a collaborative HackMD note, and open a pull request with all link to HackMD notes.
* Added a reusable workflow (`_sync-meeting-notes.yml`) to sync updated meeting notes content from HackMD back into the repository and update the corresponding pull request.
* Adds a top-level workflow (`triage-notes.yml`) that ties together note creation, triage analysis, and syncing, triggered either manually or via PR comment.

**Triage Analysis Automation**

* Added a `triage-assist.md` workflow definition to automate analysis of issues referenced in meeting notes. This workflow extracts issues, summarizes them, suggests labels, and identifies related or duplicate issues, posting the analysis as a comment on the meeting notes PR.

**Standardized Meeting Notes Template**

* Added a Jinja-based `triage_TEMPLATE.md` for meeting notes, including agenda structure, attendee table, and links to triage resources.